### PR TITLE
Bug fix long cortex filenames

### DIFF
--- a/python/clockwork/cortex.py
+++ b/python/clockwork/cortex.py
@@ -10,6 +10,28 @@ from clockwork import utils
 class Error (Exception): pass
 
 
+def _replace_sample_name_in_vcf(infile, outfile, sample_name):
+    changed_name = False
+
+    with open(infile) as f_in, open(outfile, 'w') as f_out:
+        for line in f_in:
+            if line.startswith('#CHROM'):
+                fields = line.rstrip().split('\t')
+                if len(fields) < 10:
+                    raise Error('Not enough columns in header line of VCF: ' + line)
+                elif len(fields) == 10:
+                    fields[9] = sample_name
+                    print(*fields, sep='\t', file=f_out)
+                    changed_name = True
+                else:
+                    raise Error('More than one sample in VCF, from header line: ' + line)
+            else:
+                print(line, end='', file=f_out)
+
+    if not changed_name:
+        raise Error('No #CHROM line found in VCF file ' + infile)
+
+
 def _find_binaries(cortex_root=None, stampy_script=None, vcftools_dir=None, mccortex=None):
     if cortex_root is None:
         cortex_root = os.environ.get('CLOCKWORK_CORTEX_DIR', '/bioinf-tools/cortex')

--- a/python/clockwork/tests/cortex_test.py
+++ b/python/clockwork/tests/cortex_test.py
@@ -1,3 +1,4 @@
+import filecmp
 import unittest
 import shutil
 import os
@@ -8,6 +9,26 @@ data_dir = os.path.join(modules_dir, 'tests', 'data', 'cortex')
 
 
 class TestCortex(unittest.TestCase):
+    def test_replace_sample_name_in_vcf(self):
+        '''test _replace_sample_name_in_vcf'''
+        tmp_out = 'tmp.replace_sample_name_in_vcf.out'
+        bad1 = os.path.join(data_dir, 'replace_sample_name_in_vcf.in.bad1.vcf')
+        bad2 = os.path.join(data_dir, 'replace_sample_name_in_vcf.in.bad2.vcf')
+        bad3 = os.path.join(data_dir, 'replace_sample_name_in_vcf.in.bad3.vcf')
+        with self.assertRaises(cortex.Error):
+            cortex._replace_sample_name_in_vcf(bad1, tmp_out, 'NEW_NAME')
+        with self.assertRaises(cortex.Error):
+            cortex._replace_sample_name_in_vcf(bad2, tmp_out, 'NEW_NAME')
+        with self.assertRaises(cortex.Error):
+            cortex._replace_sample_name_in_vcf(bad3, tmp_out, 'NEW_NAME')
+
+        infile = os.path.join(data_dir, 'replace_sample_name_in_vcf.in.vcf')
+        expected = os.path.join(data_dir, 'replace_sample_name_in_vcf.expect.vcf')
+        cortex._replace_sample_name_in_vcf(infile, tmp_out, 'NEW_NAME')
+        self.assertTrue(filecmp.cmp(tmp_out, expected))
+        os.unlink(tmp_out)
+
+
     def test_run_cortex_run_calls(self):
         '''test run_cortex'''
         ref_dir = os.path.join(data_dir, 'Reference')

--- a/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.expect.vcf
+++ b/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.expect.vcf
@@ -1,0 +1,29 @@
+##fileformat=VCFv4.0
+##fileDate=16/04/2018
+##phasing=none,though some calls involve phasing clustered variants
+##variants_justified=left
+##ALT=<ID=COMPLEX,Description=Complex variant, collection of SNPs and indels>
+##ALT=<ID=DEL,Description=Deletion>
+##ALT=<ID=DEL_INV,Description=Deletion + Inversion>
+##ALT=<ID=INDEL,Description=Insertion-deletion>
+##ALT=<ID=INS,Description=Insertion of novel sequence>
+##ALT=<ID=INS_INV,Description=Insertion + Inversion>
+##ALT=<ID=INV,Description=Inversion>
+##ALT=<ID=INV_INDEL,Description=Inversion+indel - this script overcalls these, so worth checking>
+##ALT=<ID=PH_SNPS,Description=Phased SNPs>
+##ALT=<ID=SNP,Description=SNP>
+##ALT=<ID=SNP_FROM_COMPLEX,Description=SNP called from a cluster of phased SNPs or complex SNP/indel , split out for easier comparison with other SNP call sets>
+##FILTER=<ID=MAPQ,Description=5prime flank maps to reference with mapping quality below 40>
+##FILTER=<ID=MISMAPPED_UNPLACEABLE,Description=Stampy mapped the variant (using the 5p-flank) confidently (mapqual> 40) to a place where the ref-allele does not match>
+##FILTER=<ID=MULTIALLELIC,Description=Cortex does not call multiallelic sites, but combining run_calls VCFs can produce them. Filtered as current genotyper assumes biallelic.>
+##FILTER=<ID=OVERLAPPING_SITE,Description=If Stampy (or combining VCFs) has placed two biallelic variants overlapping, they are filtered>
+##FORMAT=<ID=COV,Number=2,Type=Integer,Description=Number of reads on ref and alt alleles>
+##FORMAT=<ID=GT,Number=1,Type=String,Description=Genotype>
+##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description=Genotype confidence. Difference in log likelihood of most likely and next most likely genotype>
+##FORMAT=<ID=SITE_CONF,Number=1,Type=Float,Description=Probabilitic site classification confidence. Difference in log likelihood of most likely and next most likely model (models are variant, repeat and error)>
+##INFO=<ID=KMER,Number=1,Type=Integer,Description=Kmer size at which variant was discovered>
+##INFO=<ID=PV,Number=1,Type=Integer,Description=Possible variation in clean indel position>
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=Difference in length between REF and ALT alleles>
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description=Type of variant>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NEW_NAME
+ref_name	42	UNION_BC_k31_var_35	T	C	.	PASS	KMER=31;SVLEN=0;SVTYPE=SNP	GT:COV:GT_CONF	1/1:0,58:54.70

--- a/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.in.bad1.vcf
+++ b/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.in.bad1.vcf
@@ -1,0 +1,29 @@
+##fileformat=VCFv4.0
+##fileDate=16/04/2018
+##phasing=none,though some calls involve phasing clustered variants
+##variants_justified=left
+##ALT=<ID=COMPLEX,Description=Complex variant, collection of SNPs and indels>
+##ALT=<ID=DEL,Description=Deletion>
+##ALT=<ID=DEL_INV,Description=Deletion + Inversion>
+##ALT=<ID=INDEL,Description=Insertion-deletion>
+##ALT=<ID=INS,Description=Insertion of novel sequence>
+##ALT=<ID=INS_INV,Description=Insertion + Inversion>
+##ALT=<ID=INV,Description=Inversion>
+##ALT=<ID=INV_INDEL,Description=Inversion+indel - this script overcalls these, so worth checking>
+##ALT=<ID=PH_SNPS,Description=Phased SNPs>
+##ALT=<ID=SNP,Description=SNP>
+##ALT=<ID=SNP_FROM_COMPLEX,Description=SNP called from a cluster of phased SNPs or complex SNP/indel , split out for easier comparison with other SNP call sets>
+##FILTER=<ID=MAPQ,Description=5prime flank maps to reference with mapping quality below 40>
+##FILTER=<ID=MISMAPPED_UNPLACEABLE,Description=Stampy mapped the variant (using the 5p-flank) confidently (mapqual> 40) to a place where the ref-allele does not match>
+##FILTER=<ID=MULTIALLELIC,Description=Cortex does not call multiallelic sites, but combining run_calls VCFs can produce them. Filtered as current genotyper assumes biallelic.>
+##FILTER=<ID=OVERLAPPING_SITE,Description=If Stampy (or combining VCFs) has placed two biallelic variants overlapping, they are filtered>
+##FORMAT=<ID=COV,Number=2,Type=Integer,Description=Number of reads on ref and alt alleles>
+##FORMAT=<ID=GT,Number=1,Type=String,Description=Genotype>
+##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description=Genotype confidence. Difference in log likelihood of most likely and next most likely genotype>
+##FORMAT=<ID=SITE_CONF,Number=1,Type=Float,Description=Probabilitic site classification confidence. Difference in log likelihood of most likely and next most likely model (models are variant, repeat and error)>
+##INFO=<ID=KMER,Number=1,Type=Integer,Description=Kmer size at which variant was discovered>
+##INFO=<ID=PV,Number=1,Type=Integer,Description=Possible variation in clean indel position>
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=Difference in length between REF and ALT alleles>
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description=Type of variant>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_name	sample_name_2
+ref_name	42	UNION_BC_k31_var_35	T	C	.	PASS	KMER=31;SVLEN=0;SVTYPE=SNP	GT:COV:GT_CONF	1/1:0,58:54.70

--- a/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.in.bad2.vcf
+++ b/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.in.bad2.vcf
@@ -1,0 +1,29 @@
+##fileformat=VCFv4.0
+##fileDate=16/04/2018
+##phasing=none,though some calls involve phasing clustered variants
+##variants_justified=left
+##ALT=<ID=COMPLEX,Description=Complex variant, collection of SNPs and indels>
+##ALT=<ID=DEL,Description=Deletion>
+##ALT=<ID=DEL_INV,Description=Deletion + Inversion>
+##ALT=<ID=INDEL,Description=Insertion-deletion>
+##ALT=<ID=INS,Description=Insertion of novel sequence>
+##ALT=<ID=INS_INV,Description=Insertion + Inversion>
+##ALT=<ID=INV,Description=Inversion>
+##ALT=<ID=INV_INDEL,Description=Inversion+indel - this script overcalls these, so worth checking>
+##ALT=<ID=PH_SNPS,Description=Phased SNPs>
+##ALT=<ID=SNP,Description=SNP>
+##ALT=<ID=SNP_FROM_COMPLEX,Description=SNP called from a cluster of phased SNPs or complex SNP/indel , split out for easier comparison with other SNP call sets>
+##FILTER=<ID=MAPQ,Description=5prime flank maps to reference with mapping quality below 40>
+##FILTER=<ID=MISMAPPED_UNPLACEABLE,Description=Stampy mapped the variant (using the 5p-flank) confidently (mapqual> 40) to a place where the ref-allele does not match>
+##FILTER=<ID=MULTIALLELIC,Description=Cortex does not call multiallelic sites, but combining run_calls VCFs can produce them. Filtered as current genotyper assumes biallelic.>
+##FILTER=<ID=OVERLAPPING_SITE,Description=If Stampy (or combining VCFs) has placed two biallelic variants overlapping, they are filtered>
+##FORMAT=<ID=COV,Number=2,Type=Integer,Description=Number of reads on ref and alt alleles>
+##FORMAT=<ID=GT,Number=1,Type=String,Description=Genotype>
+##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description=Genotype confidence. Difference in log likelihood of most likely and next most likely genotype>
+##FORMAT=<ID=SITE_CONF,Number=1,Type=Float,Description=Probabilitic site classification confidence. Difference in log likelihood of most likely and next most likely model (models are variant, repeat and error)>
+##INFO=<ID=KMER,Number=1,Type=Integer,Description=Kmer size at which variant was discovered>
+##INFO=<ID=PV,Number=1,Type=Integer,Description=Possible variation in clean indel position>
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=Difference in length between REF and ALT alleles>
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description=Type of variant>
+#CHROM	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_name
+ref_name	42	UNION_BC_k31_var_35	T	C	.	PASS	KMER=31;SVLEN=0;SVTYPE=SNP	GT:COV:GT_CONF	1/1:0,58:54.70

--- a/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.in.bad3.vcf
+++ b/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.in.bad3.vcf
@@ -1,0 +1,28 @@
+##fileformat=VCFv4.0
+##fileDate=16/04/2018
+##phasing=none,though some calls involve phasing clustered variants
+##variants_justified=left
+##ALT=<ID=COMPLEX,Description=Complex variant, collection of SNPs and indels>
+##ALT=<ID=DEL,Description=Deletion>
+##ALT=<ID=DEL_INV,Description=Deletion + Inversion>
+##ALT=<ID=INDEL,Description=Insertion-deletion>
+##ALT=<ID=INS,Description=Insertion of novel sequence>
+##ALT=<ID=INS_INV,Description=Insertion + Inversion>
+##ALT=<ID=INV,Description=Inversion>
+##ALT=<ID=INV_INDEL,Description=Inversion+indel - this script overcalls these, so worth checking>
+##ALT=<ID=PH_SNPS,Description=Phased SNPs>
+##ALT=<ID=SNP,Description=SNP>
+##ALT=<ID=SNP_FROM_COMPLEX,Description=SNP called from a cluster of phased SNPs or complex SNP/indel , split out for easier comparison with other SNP call sets>
+##FILTER=<ID=MAPQ,Description=5prime flank maps to reference with mapping quality below 40>
+##FILTER=<ID=MISMAPPED_UNPLACEABLE,Description=Stampy mapped the variant (using the 5p-flank) confidently (mapqual> 40) to a place where the ref-allele does not match>
+##FILTER=<ID=MULTIALLELIC,Description=Cortex does not call multiallelic sites, but combining run_calls VCFs can produce them. Filtered as current genotyper assumes biallelic.>
+##FILTER=<ID=OVERLAPPING_SITE,Description=If Stampy (or combining VCFs) has placed two biallelic variants overlapping, they are filtered>
+##FORMAT=<ID=COV,Number=2,Type=Integer,Description=Number of reads on ref and alt alleles>
+##FORMAT=<ID=GT,Number=1,Type=String,Description=Genotype>
+##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description=Genotype confidence. Difference in log likelihood of most likely and next most likely genotype>
+##FORMAT=<ID=SITE_CONF,Number=1,Type=Float,Description=Probabilitic site classification confidence. Difference in log likelihood of most likely and next most likely model (models are variant, repeat and error)>
+##INFO=<ID=KMER,Number=1,Type=Integer,Description=Kmer size at which variant was discovered>
+##INFO=<ID=PV,Number=1,Type=Integer,Description=Possible variation in clean indel position>
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=Difference in length between REF and ALT alleles>
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description=Type of variant>
+ref_name	42	UNION_BC_k31_var_35	T	C	.	PASS	KMER=31;SVLEN=0;SVTYPE=SNP	GT:COV:GT_CONF	1/1:0,58:54.70

--- a/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.in.vcf
+++ b/python/clockwork/tests/data/cortex/replace_sample_name_in_vcf.in.vcf
@@ -1,0 +1,29 @@
+##fileformat=VCFv4.0
+##fileDate=16/04/2018
+##phasing=none,though some calls involve phasing clustered variants
+##variants_justified=left
+##ALT=<ID=COMPLEX,Description=Complex variant, collection of SNPs and indels>
+##ALT=<ID=DEL,Description=Deletion>
+##ALT=<ID=DEL_INV,Description=Deletion + Inversion>
+##ALT=<ID=INDEL,Description=Insertion-deletion>
+##ALT=<ID=INS,Description=Insertion of novel sequence>
+##ALT=<ID=INS_INV,Description=Insertion + Inversion>
+##ALT=<ID=INV,Description=Inversion>
+##ALT=<ID=INV_INDEL,Description=Inversion+indel - this script overcalls these, so worth checking>
+##ALT=<ID=PH_SNPS,Description=Phased SNPs>
+##ALT=<ID=SNP,Description=SNP>
+##ALT=<ID=SNP_FROM_COMPLEX,Description=SNP called from a cluster of phased SNPs or complex SNP/indel , split out for easier comparison with other SNP call sets>
+##FILTER=<ID=MAPQ,Description=5prime flank maps to reference with mapping quality below 40>
+##FILTER=<ID=MISMAPPED_UNPLACEABLE,Description=Stampy mapped the variant (using the 5p-flank) confidently (mapqual> 40) to a place where the ref-allele does not match>
+##FILTER=<ID=MULTIALLELIC,Description=Cortex does not call multiallelic sites, but combining run_calls VCFs can produce them. Filtered as current genotyper assumes biallelic.>
+##FILTER=<ID=OVERLAPPING_SITE,Description=If Stampy (or combining VCFs) has placed two biallelic variants overlapping, they are filtered>
+##FORMAT=<ID=COV,Number=2,Type=Integer,Description=Number of reads on ref and alt alleles>
+##FORMAT=<ID=GT,Number=1,Type=String,Description=Genotype>
+##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description=Genotype confidence. Difference in log likelihood of most likely and next most likely genotype>
+##FORMAT=<ID=SITE_CONF,Number=1,Type=Float,Description=Probabilitic site classification confidence. Difference in log likelihood of most likely and next most likely model (models are variant, repeat and error)>
+##INFO=<ID=KMER,Number=1,Type=Integer,Description=Kmer size at which variant was discovered>
+##INFO=<ID=PV,Number=1,Type=Integer,Description=Possible variation in clean indel position>
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description=Difference in length between REF and ALT alleles>
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description=Type of variant>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_name
+ref_name	42	UNION_BC_k31_var_35	T	C	.	PASS	KMER=31;SVLEN=0;SVTYPE=SNP	GT:COV:GT_CONF	1/1:0,58:54.70


### PR DESCRIPTION
Fixes a bug in variant call pipeline. If the sample is too long, then cortex tries and fails to make files that include the sample name in its name. Fixed by running cortex with a small sample name, then fixing the sample names in the VCF files output by cortex.