### PR TITLE
minos version bump

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -196,5 +196,5 @@ make install
 
 
 #________________________ minos _____________________________#
-pip3 install bio-minos==0.9.0
+pip3 install bio-minos>=0.9.1
 

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -196,5 +196,5 @@ make install
 
 
 #________________________ minos _____________________________#
-pip3 install bio-minos>=0.9.1
+pip3 install bio-minos==0.9.1
 


### PR DESCRIPTION
@iqbal-lab @martinghunt before committing this, is there a disadvantage to using '>=' rather '==', such that in subsequent updates to minos, this kind of commit should not be necessary?

According to [PEP440](https://www.python.org/dev/peps/pep-0440/#id53) pip should install the latest distribution when several of them are compatible with the version identification.