### PR TITLE
add nextflow.config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -8,36 +8,46 @@
 
 manifest {
   author = 'Martin Hunt et al'
-  description = ''
+  description = 'Pipelines for processing bacterial sequence data (Illumina only) and variant calling'
   homePage = 'https://github.com/iqbal-lab-org/clockwork'
   name = 'clockwork'
   nextflowVersion = '>=19.07.0'
   version = '0.8.0'
 }
 
-
-
 params {
-  outDir = "${PWD}"     // Path to output directory, default PWD
-  sample =  "test_samples.tsv"   // sample TSV file
-  genome = 'GRCh37'     // Default reference genome is GRCh38
-  // path to reference files subdirectory
-  verbose = false        // Enable for more verbose information, default false
-  test = false          // boolean Not testing by default
-  markdup_java_options = '"-Xms4000m -Xmx7g"' // Established values for markDuplicate memory consumption
-  // see https://github.com/SciLifeLab/Sarek/blob/master/conf/base.config
-  singleCPUMem  = 7.GB  // for processes that are using more memory but a single CPU only
-  publishDirMode = 'link' // publishDir mode is 'link' by default
-  tools = 'delly,facets,mutect2,manta,strelka2,msisensor,haplotypecaller,polysolver,mutsig,neoantigen,lohhla,pileup,conpair,conpairall'
-  assayType = "exome" // either 'exome' or 'genome'; default exome
-  somatic = false
-  germline = false
-  debug = false
-  outname = 'make_bam_output.tsv'
-  publishAll = false
-  mapping = false
-  pairing = false
-  bam_pairing = false
+  cortex_mem_height = 22
+  dataset_name = "" 
+  db_config_file = "" 
+  dropbox_dir = ""
+  help = false
+  max_forks  = 20  // also listed as 100, https://github.com/iqbal-lab-org/clockwork/blob/master/nextflow/generic_pipeline.nf#L6
+  max_forks_combine_variant_calls = 100
+  max_forks_cortex = 100
+  max_forks_fastqc = 100 
+  max_forks_map_reads = 100 
+  max_forks_sam_to_fastq_files = 100
+  max_forks_samtools = 100
+  max_forks_samtools_qc = 100
+  max_forks_trim_reads = 100 
+  max_ram = 4
+  minos_max_read_length = 200
+  outprefix = ""
+  output_dir = "" 
+  pipeline_name = ""
+  pipeline_root  = ""
+  reads_in1 = "" 
+  reads_in2 = "" 
+  ref_dir = "" 
+  ref_fasta = ""
+  ref_id = "" 
+  ref_metadata_tsv = ""
+  references_root = "" 
+  sample_name = ""
+  script = "" 
+  testing = false
+  truth_ref = "" 
+  xlsx_archive_dir = ""
 }
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,0 +1,63 @@
+/*
+ * -------------------------------------------------
+ * Nextflow config file for clockwork
+ * -------------------------------------------------
+ *
+ */
+
+
+manifest {
+  author = 'Martin Hunt et al'
+  description = ''
+  homePage = 'https://github.com/iqbal-lab-org/clockwork'
+  name = 'clockwork'
+  nextflowVersion = '>=19.07.0'
+  version = '0.8.0'
+}
+
+
+
+params {
+  outDir = "${PWD}"     // Path to output directory, default PWD
+  sample =  "test_samples.tsv"   // sample TSV file
+  genome = 'GRCh37'     // Default reference genome is GRCh38
+  // path to reference files subdirectory
+  verbose = false        // Enable for more verbose information, default false
+  test = false          // boolean Not testing by default
+  markdup_java_options = '"-Xms4000m -Xmx7g"' // Established values for markDuplicate memory consumption
+  // see https://github.com/SciLifeLab/Sarek/blob/master/conf/base.config
+  singleCPUMem  = 7.GB  // for processes that are using more memory but a single CPU only
+  publishDirMode = 'link' // publishDir mode is 'link' by default
+  tools = 'delly,facets,mutect2,manta,strelka2,msisensor,haplotypecaller,polysolver,mutsig,neoantigen,lohhla,pileup,conpair,conpairall'
+  assayType = "exome" // either 'exome' or 'genome'; default exome
+  somatic = false
+  germline = false
+  debug = false
+  outname = 'make_bam_output.tsv'
+  publishAll = false
+  mapping = false
+  pairing = false
+  bam_pairing = false
+}
+
+
+trace {
+    enabled = true
+    file = 'trace.txt'
+    fields = 'task_id,hash,native_id,process,tag,name,status,exit,module,container,cpus,time,disk,memory,attempt,submit,start,complete,duration,realtime,queue,%cpu,%mem,rss,vmem,peak_rss,peak_vmem,rchar,wchar,syscr,syscw,read_bytes,write_bytes'
+}
+
+timeline {
+    enabled = true
+    file = 'timeline.html'
+}
+
+report {
+    enabled = true
+    file = 'report.html'
+}
+
+dag {
+    enabled = false
+    file = 'dag.pdf'
+}

--- a/nextflow/fake_remove_contam.nf
+++ b/nextflow/fake_remove_contam.nf
@@ -1,3 +1,5 @@
+#!/usr/bin/env nextflow
+
 params.help = false
 params.pipeline_root = ""
 params.db_config_file = ""

--- a/nextflow/fake_remove_contam.nf
+++ b/nextflow/fake_remove_contam.nf
@@ -1,12 +1,5 @@
 #!/usr/bin/env nextflow
 
-params.help = false
-params.pipeline_root = ""
-params.db_config_file = ""
-params.dataset_name = ""
-params.max_forks = 20
-
-
 if (params.help){
     log.info"""
         Clockwork fake_remove_contam pipeline. Fakes a run of remove_contam pipeline,

--- a/nextflow/generic_pipeline.nf
+++ b/nextflow/generic_pipeline.nf
@@ -1,15 +1,5 @@
 #!/usr/bin/env nextflow
 
-params.help = false
-params.pipeline_root = ""
-params.db_config_file = ""
-params.dataset_name = ""
-params.script = ""
-params.max_forks = 100
-params.max_ram = 4
-params.pipeline_name = ""
-
-
 if (params.help){
     log.info"""
         Clockwork generic pipeline. Runs a user-provided

--- a/nextflow/generic_pipeline.nf
+++ b/nextflow/generic_pipeline.nf
@@ -1,3 +1,5 @@
+#!/usr/bin/env nextflow
+
 params.help = false
 params.pipeline_root = ""
 params.db_config_file = ""

--- a/nextflow/import.nf
+++ b/nextflow/import.nf
@@ -1,12 +1,5 @@
 #!/usr/bin/env nextflow
 
-params.help = false
-params.dropbox_dir = ""
-params.pipeline_root = ""
-params.db_config_file = ""
-params.xlsx_archive_dir = ""
-
-
 if (params.help){
     log.info"""
         Clockwork import pipeline. Imports data from dropbox directory.

--- a/nextflow/import.nf
+++ b/nextflow/import.nf
@@ -1,3 +1,5 @@
+#!/usr/bin/env nextflow
+
 params.help = false
 params.dropbox_dir = ""
 params.pipeline_root = ""

--- a/nextflow/mykrobe_predict.nf
+++ b/nextflow/mykrobe_predict.nf
@@ -1,3 +1,5 @@
+#!/usr/bin/env nextflow
+
 params.help = false
 params.ref_id = ""
 params.references_root = ""

--- a/nextflow/mykrobe_predict.nf
+++ b/nextflow/mykrobe_predict.nf
@@ -1,13 +1,5 @@
 #!/usr/bin/env nextflow
 
-params.help = false
-params.ref_id = ""
-params.references_root = ""
-params.pipeline_root = ""
-params.db_config_file = ""
-params.dataset_name = ""
-params.testing = false
-
 if (params.testing) {
     test_opt_string = '--testing'
 }

--- a/nextflow/qc.nf
+++ b/nextflow/qc.nf
@@ -1,3 +1,5 @@
+#!/usr/bin/env nextflow
+
 params.help = false
 params.ref_id = ""
 params.references_root = ""

--- a/nextflow/qc.nf
+++ b/nextflow/qc.nf
@@ -1,19 +1,5 @@
 #!/usr/bin/env nextflow
 
-params.help = false
-params.ref_id = ""
-params.references_root = ""
-params.pipeline_root = ""
-params.db_config_file = ""
-params.dataset_name = ""
-params.ref_fasta = ""
-params.reads_in1 = ""
-params.reads_in2 = ""
-params.output_dir = ""
-params.max_forks_samtools_qc = 100
-params.max_forks_fastqc = 100
-
-
 if (params.help){
     log.info"""
         Clockwork QC pipeline.

--- a/nextflow/remove_contam.nf
+++ b/nextflow/remove_contam.nf
@@ -1,3 +1,5 @@
+#!/usr/bin/env nextflow
+
 params.help = false
 params.reads_in1 = ""
 params.reads_in2 = ""

--- a/nextflow/remove_contam.nf
+++ b/nextflow/remove_contam.nf
@@ -1,21 +1,5 @@
 #!/usr/bin/env nextflow
 
-params.help = false
-params.reads_in1 = ""
-params.reads_in2 = ""
-params.outprefix = ""
-params.ref_metadata_tsv = ""
-params.pipeline_root = ""
-params.references_root = ""
-params.db_config_file = ""
-params.dataset_name = ""
-params.ref_fasta = ""
-params.ref_id = ""
-params.testing = false
-params.max_forks_map_reads = 100
-params.max_forks_sam_to_fastq_files = 100
-
-
 if (params.help){
     log.info"""
         Clockwork remove_contam pipeline. Removes reads that are contaminated.

--- a/nextflow/variant_call.nf
+++ b/nextflow/variant_call.nf
@@ -1,3 +1,5 @@
+#!/usr/bin/env nextflow
+
 params.help = false
 params.ref_id = ""
 params.references_root = ""

--- a/nextflow/variant_call.nf
+++ b/nextflow/variant_call.nf
@@ -1,27 +1,5 @@
 #!/usr/bin/env nextflow
 
-params.help = false
-params.ref_id = ""
-params.references_root = ""
-params.pipeline_root = ""
-params.db_config_file = ""
-params.dataset_name = ""
-params.ref_dir = ""
-params.reads_in1 = ""
-params.reads_in2 = ""
-params.output_dir = ""
-params.sample_name = ""
-params.testing = false
-params.cortex_mem_height = 22
-params.max_forks_trim_reads = 100
-params.max_forks_map_reads = 100
-params.max_forks_samtools = 100
-params.max_forks_cortex = 100
-params.max_forks_combine_variant_calls = 100
-params.minos_max_read_length = 200
-params.truth_ref = ""
-
-
 if (params.help){
     log.info"""
         Clockwork variant_call pipeline.


### PR DESCRIPTION
Moved parameters to `nextflow.config`. 

Details of the code here: 
https://github.com/evanbiederstedt/clockwork/blob/feature/revise_NF_params/nextflow.config#L9-L16

Parameters I found here:
https://github.com/evanbiederstedt/clockwork/blob/feature/revise_NF_params/nextflow.config#L18-L51

Note:
It looks like all parameter names are the unique, except for `max_forks`:

It's 20 here: 
https://github.com/iqbal-lab-org/clockwork/blob/master/nextflow/fake_remove_contam.nf#L5

Here it's 100: 
https://github.com/iqbal-lab-org/clockwork/blob/master/nextflow/generic_pipeline.nf#L6
It may be best to rename the variable for one of these. 

Added default trace settings here, with fields I find useful: 
https://github.com/evanbiederstedt/clockwork/blob/feature/revise_NF_params/nextflow.config#L54-L58

Added default timeline, report, and DAG graphic. 
https://github.com/evanbiederstedt/clockwork/blob/feature/revise_NF_params/nextflow.config#L60-L73

You might want to remove the DAG graphic if your pipeline is stable---it will be the same thing after each pipeline run. 

Also, you'll noticed I added shebangs to the NF scripts---feel free to remove if superfluous :)