### PR TITLE
Bwa threads

### DIFF
--- a/nextflow/remove_contam.nf
+++ b/nextflow/remove_contam.nf
@@ -161,6 +161,7 @@ process make_jobs_tsv {
 
 
 process map_reads {
+    cpus params.mapping_threads
     maxForks params.max_forks_map_reads
     memory {params.testing ? '3 GB' : '9 GB'}
     if (using_db_input) {

--- a/nextflow/remove_contam.nf
+++ b/nextflow/remove_contam.nf
@@ -12,6 +12,7 @@ params.ref_id = ""
 params.testing = false
 params.max_forks_map_reads = 100
 params.max_forks_sam_to_fastq_files = 100
+params.mapping_threads = 1
 
 
 if (params.help){
@@ -45,6 +46,10 @@ if (params.help){
           --outprefix PATH      Prefix of name of output files
 
         Other options:
+          --mapping_threads INT
+                                Number of threads used by each read mapping process.
+                                This option is only recommended if running on one
+                                pair of FASTQ files [${params.mapping_threads}]
           --max_forks_map_reads INT
                                 Limit number of concurrent map_reads jobs [${params.max_forks_map_reads}]
           --max_forks_sam_to_fastq_files INT
@@ -171,7 +176,7 @@ process map_reads {
 
     script:
     """
-    clockwork map_reads --unsorted_sam sample_name ${tsv_fields.ref_fasta} contam_sam ${tsv_fields.reads_in1} ${tsv_fields.reads_in2}
+    clockwork map_reads --threads ${params.mapping_threads} --unsorted_sam sample_name ${tsv_fields.ref_fasta} contam_sam ${tsv_fields.reads_in1} ${tsv_fields.reads_in2}
     """
 }
 

--- a/python/clockwork/read_map.py
+++ b/python/clockwork/read_map.py
@@ -10,7 +10,7 @@ class Error(Exception):
 
 
 def map_reads(
-    ref_fasta, reads1, reads2, outfile, rmdup=False, markdup=False, read_group=None
+    ref_fasta, reads1, reads2, outfile, rmdup=False, markdup=False, read_group=None, threads=1
 ):
     """Maps reads with BWA MEM. By default, outputs SAM file in input read order.
     rmdup=True => remove duplicates using samtools rmdup. Final output is sorted bam
@@ -49,6 +49,7 @@ def map_reads(
     cmd = " ".join(
         [
             "bwa mem -M",
+            f"-t {threads}",
             R_option,
             ref_fasta,
             reads1,
@@ -113,6 +114,7 @@ def map_reads_set(
     rmdup=False,
     markdup=False,
     read_group=None,
+    threads=1,
 ):
     """Same as map reads, but takes a list of file pairs to be mapped"""
     assert len(reads1_list) == len(reads2_list)
@@ -132,6 +134,7 @@ def map_reads_set(
             rmdup=rmdup,
             markdup=markdup,
             read_group=read_group,
+            threads=threads,
         )
 
     assert len(outfiles) == len(reads1_list)

--- a/python/clockwork/tasks/map_reads.py
+++ b/python/clockwork/tasks/map_reads.py
@@ -17,4 +17,5 @@ def run(options):
         options.outfile,
         rmdup=not options.unsorted_sam,
         read_group=("1", options.sample_name),
+        threads=options.threads,
     )

--- a/python/scripts/clockwork
+++ b/python/scripts/clockwork
@@ -592,6 +592,13 @@ subparser_map_reads.add_argument(
     "--unsorted_sam", action="store_true", help="Make an unsorted sam file"
 )
 subparser_map_reads.add_argument(
+    "--threads",
+    type=int,
+    help="Number of threads to use when running bwa mem [%(default)s]",
+    metavar="INT",
+    default=1,
+)
+subparser_map_reads.add_argument(
     "sample_name", help="Name of sample. This is put into the final VCF files"
 )
 subparser_map_reads.add_argument(


### PR DESCRIPTION
Previous PR added option to use more threads with BWA when running remove contam pipeline. But it missed telling the nextflow process how many cpus the mapping job would need. This change adds that parameter: `cpus params.mapping_threads`.