### PR TITLE
Upgrade enaBrowserTools to v1.5.4

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -65,8 +65,8 @@ cp -s bwa-0.7.15/bwa .
 
 #_____________________ enaBrowserTools ____________________#
 cd $install_root
-wget https://github.com/enasequence/enaBrowserTools/archive/v1.4.1.tar.gz
-tar xf v1.4.1.tar.gz
+wget https://github.com/enasequence/enaBrowserTools/archive/v1.5.4.tar.gz
+tar xf v1.5.4.tar.gz
 
 
 #_________________________ FASTQC ________________________#

--- a/singularity/clockwork_container.def
+++ b/singularity/clockwork_container.def
@@ -5,7 +5,7 @@ MirrorURL: http://us.archive.ubuntu.com/ubuntu/
 %environment
 PERL5LIB=/bioinf-tools/vcftools-0.1.15/install/share/perl/5.24.1/:/bioinf-tools/cortex/scripts/analyse_variants/bioinf-perl/lib:/bioinf-tools/cortex/scripts/calling/:$PERL5LIB
 export PERL5LIB
-PATH=/bioinf-tools/:/bioinf-tools/cortex/bin/:/bioinf-tools/cortex/scripts/analyse_variants/seq-align/bin/:/bioinf-tools/vcftools-0.1.15/install/bin:/bioinf-tools/enaBrowserTools-1.4.1/python3:/clockwork/scripts/:$PATH
+PATH=/bioinf-tools/:/bioinf-tools/cortex/bin/:/bioinf-tools/cortex/scripts/analyse_variants/seq-align/bin/:/bioinf-tools/vcftools-0.1.15/install/bin:/bioinf-tools/enaBrowserTools-1.5.4/python3:/clockwork/scripts/:$PATH
 
 %setup
     mkdir $SINGULARITY_ROOTFS/clockwork
@@ -13,7 +13,7 @@ PATH=/bioinf-tools/:/bioinf-tools/cortex/bin/:/bioinf-tools/cortex/scripts/analy
 
 %post
     #_____________________ setup $PATH _______________________#
-    export PATH=/bioinf-tools/:/bioinf-tools/cortex/scripts/analyse_variants/seq-align/bin/:/bioinf-tools/vcftools-0.1.15/install/bin:/bioinf-tools/enaBrowserTools-1.4.1/python3:/clockwork/scripts/:$PATH
+    export PATH=/bioinf-tools/:/bioinf-tools/cortex/scripts/analyse_variants/seq-align/bin/:/bioinf-tools/vcftools-0.1.15/install/bin:/bioinf-tools/enaBrowserTools-1.5.4/python3:/clockwork/scripts/:$PATH
     export PERL5LIB=/bioinf-tools/vcftools-0.1.15/install/share/perl/5.24.1/:/bioinf-tools/cortex/scripts/analyse_variants/bioinf-perl/lib:/bioinf-tools/cortex/scripts/calling/:$PERL5LIB
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -52,7 +52,7 @@ Vagrant.configure(2) do |config|
 
   # Set up env vars
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
-    echo "export PATH=/bioinf-tools/:/bioinf-tools/cortex/scripts/analyse_variants/seq-align/bin/:/bioinf-tools/vcftools-0.1.15/install/bin:/bioinf-tools/enaBrowserTools-1.4.1/python3:$PATH" >> $HOME/.bashrc
+    echo "export PATH=/bioinf-tools/:/bioinf-tools/cortex/scripts/analyse_variants/seq-align/bin/:/bioinf-tools/vcftools-0.1.15/install/bin:/bioinf-tools/enaBrowserTools-1.5.4/python3:$PATH" >> $HOME/.bashrc
     echo "export PERL5LIB=/bioinf-tools/vcftools-0.1.15/install/share/perl/5.24.1/:/bioinf-tools/cortex/scripts/analyse_variants/bioinf-perl/lib:/bioinf-tools/cortex/scripts/calling/:$PERL5LIB" >> $HOME/.bashrc
     echo "export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $HOME/.bashrc
   SHELL


### PR DESCRIPTION
There seems to be a problem with older version of `enaDataGet` when trying to download fastq files for a run through Singularity images. The error message in the log shows:
`ERROR: Something unexpected went wrong please try again.`

Upgrading enaBrowserTools to latest version (v1.5.4) resolves this issue.