### PR TITLE
Fix ena downloader issue with invalid accession

### DIFF
--- a/python/clockwork/ena_downloader.py
+++ b/python/clockwork/ena_downloader.py
@@ -16,6 +16,14 @@ class Error(Exception):
 run_pattern = re.compile("^[EDS]RR[0-9]{6,}$")
 
 
+def _download(download_cmd):
+    print(download_cmd)
+    try:
+        utils.syscall(download_cmd)
+    except Exception:
+        print("Error running: ", download_cmd)
+
+
 def _download_run(run_id, outdir):
     expected_1 = os.path.join(outdir, run_id + "_1.fastq.gz")
     expected_2 = os.path.join(outdir, run_id + "_2.fastq.gz")
@@ -24,14 +32,12 @@ def _download_run(run_id, outdir):
         return
 
     cmd = " ".join(["enaDataGet", "-f fastq", "-d", outdir, run_id,])
-    print(cmd)
-    utils.syscall(cmd)
+    _download(cmd)
 
 
 def _download_sample(sample_id, outdir):
     cmd = " ".join(["enaGroupGet", "-f fastq", "-d", outdir, sample_id,])
-    print(cmd)
-    utils.syscall(cmd)
+    _download(cmd)
 
 
 def _download_run_or_sample(accession, outdir):

--- a/python/scripts/clockwork
+++ b/python/scripts/clockwork
@@ -261,7 +261,10 @@ subparser_ena_download = subparsers.add_parser(
     help="Download reads from the ENA",
     usage="clockwork ena_download [options] <data_tsv> <output_dir> <site> <lab> <date> <dataset name>",
     description="Download reads from ENA. Gets fastq files, and makes import spreadsheet for use with the import pipeline",
-    epilog="The data TSV file is one line per sample, and each line needs two columns. Column 1 is the sample name, and can be anything unique within the file. Column 2 must be a comma-separated list of run accessions.",
+    epilog="The data TSV file is one line per sample, and each line needs two columns. Column 1 is the sample name, and"
+           "can be anything unique within the file. Column 2 must be a comma-separated list of run accessions. If there"
+           "is problem downloading a sample, that sample will be skipped. Only samples downloaded successfully appear "
+           "in the import spreadsheet.",
 )
 
 subparser_ena_download.add_argument(


### PR DESCRIPTION
Previously when an invalid run accession or a run that ena does not have
fastq files for is supplied, the ena downloader job will fail.