### PR TITLE
make NTMs contamination

### DIFF
--- a/scripts/download_tb_reference_files.pl
+++ b/scripts/download_tb_reference_files.pl
@@ -84,7 +84,7 @@ my %genomes = (
     },
     NTM => {
         fastas => \@ntm_fastas,
-        is_contam => 0,
+        is_contam => 1,
     },
 );
 


### PR DESCRIPTION
Speaking with @iqbal-lab, I believe NTMs are actually supposed to be flagged as contamination?

Is there anywhere else in the script this needs to change, or is this is?