### PR TITLE
Clobber (and warn about) existing output directories instead of bailing

### DIFF
--- a/python/clockwork/db.py
+++ b/python/clockwork/db.py
@@ -5,6 +5,7 @@ import os
 import re
 import sys
 import tempfile
+import shutil
 from operator import itemgetter
 from clockwork import (
     db_connection,
@@ -558,7 +559,9 @@ class Db:
                 output_dir = iso_dir.pipeline_dir(
                     row["sequence_replicate_number"], "qc", pipeline_version
                 )
-                assert not os.path.exists(output_dir)
+                if os.path.exists(output_dir):
+                    print("Warning:", output_dir, "already exists. Removing.", file=sys.stderr)
+                    shutil.rmtree(output_dir)
                 try:
                     os.makedirs(output_dir)
                 except:


### PR DESCRIPTION
Instead of failing an assertion when an output dir already exists this will replace it and log a warning. Prevents partial pipeline failures for resumed QC pipeline runs.