### PR TITLE
Fix gramtools build

### DIFF
--- a/python/clockwork/tests/ena_downloader_test.py
+++ b/python/clockwork/tests/ena_downloader_test.py
@@ -86,7 +86,7 @@ class TestEnaDownloader(unittest.TestCase):
         )
         self.assertEqual("SAMEA2533482", got_sample)
         self.assertEqual("Illumina HiSeq 2500", got_instrument)
-        self.assertEqual("FZB", got_center_name)
+        self.assertEqual("FORSCHUNGSZENTRUM BORSTEL", got_center_name)
 
     def test_write_import_tsv(self):
         """Test _write_import_tsv"""

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -188,7 +188,7 @@ pip3 install python-dateutil requests pysam pyfastaq pymysql numpy openpyxl pyfl
 
 
 #________________________ gramtools _________________________#
-pip3 install --process-dependency-links wheel git+https://github.com/iqbal-lab-org/gramtools@9313eceb606a6fc159e4a14c168b7a6f888c5ed2
+pip3 install --process-dependency-links wheel git+https://github.com/iqbal-lab-org/gramtools@8af53f6c8c0d72ef95223e89ab82119b717044f2
 
 #________________________ mummer ____________________________#
 cd $install_root


### PR DESCRIPTION
fixes #86

Updates to use gramtools commit that actually builds (and fixes a newly failing test, caused by ENA metadata changing)