### PR TITLE
rename VCF, instead of rsync and then delete

### DIFF
--- a/python/clockwork/cortex.py
+++ b/python/clockwork/cortex.py
@@ -199,8 +199,7 @@ class CortexRunCalls:
             if filename.endswith(".vcf"):
                 tmp_vcf = filename + ".tmp"
                 _replace_sample_name_in_vcf(filename, tmp_vcf, self.sample_name)
-                utils.rsync_and_md5(tmp_vcf, filename)
-                os.unlink(tmp_vcf)
+                os.rename(tmp_vcf, filename)
 
             if not (
                 (filename.endswith(".vcf") and "FINAL" in filename)
@@ -301,5 +300,5 @@ class CortexRunCalls:
 
         utils.syscall(cmd)
         self._tidy_files()
-        if run_mccortex_view_kmers: 
+        if run_mccortex_view_kmers:
             self._run_mccortex_view_kmers()

--- a/python/clockwork/mykrobe.py
+++ b/python/clockwork/mykrobe.py
@@ -4,7 +4,7 @@ import shutil
 from clockwork import utils
 
 
-built_in_panels = {"tb": {"bradley-2015", "walker-2015", "201901", "202010"}}
+built_in_panels = {"tb": {"bradley-2015", "walker-2015", "201901", "202010", "202206"}}
 
 
 def susceptibility_dict_from_json_file(json_file):

--- a/python/clockwork/tests/cortex_test.py
+++ b/python/clockwork/tests/cortex_test.py
@@ -33,7 +33,16 @@ class TestCortex(unittest.TestCase):
         ref_dir = os.path.join(data_dir, "Reference")
         reads_infile = os.path.join(data_dir, "reads.fq")
         tmp_out = "tmp.cortex.out"
-        sample_name = "sample_name"
+        # When cortex is run, the sample is called "sample". Then the VCF is
+        # fixed afterwards with the correct sample name. This was because the
+        # sample name is put in the cortex VCF filename, and could result in
+        # filenames that were too long for the filesystem.
+        # There was a bug where the rsync to copy the temp sample-renamed VCF
+        # back to the original VCF didn't work because it thought the files were
+        # the same. This only happened if the length of the sample name was 6,
+        # ie the same as len("sample"). Hence the sample name below has length
+        # 6, which caused the test to fail before the rsync bug was fixed.
+        sample_name = "123456"
         ctx = cortex.CortexRunCalls(
             ref_dir, reads_infile, tmp_out, sample_name, mem_height=17
         )

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -122,7 +122,7 @@ cp -s minimap2-${MINIMAP2_V}/minimap2 .
 cd $install_root
 git clone https://github.com/Mykrobe-tools/mykrobe.git mykrobe
 cd mykrobe
-git checkout 17540f25d6b84b5cb3dfa59973d5838f1e1cb51c
+git checkout 3eff3a0f73c1c061912f7a275b1395d5e14c1d62
 pip3 install requests
 rm -rf mccortex
 git clone --recursive -b geno_kmer_count https://github.com/Mykrobe-tools/mccortex mccortex


### PR DESCRIPTION
Fixes #98 