### PR TITLE
force nextflow version 22.10.0 so dsl1 works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV PATH=/bioinf-tools/:/bioinf-tools/cortex/bin/:/bioinf-tools/cortex/scripts/a
 ENV PERL5LIB=/bioinf-tools/vcftools-0.1.15/install/share/perl/5.30.0/:/bioinf-tools/cortex/scripts/analyse_variants/bioinf-perl/lib:/bioinf-tools/cortex/scripts/calling/:$PERL5LIB
 ENV LANG=C.UTF-8
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV NXF_VER=22.10.0
 
 COPY scripts/install_dependencies.sh /install_dependencies.sh
 RUN /install_dependencies.sh /bioinf-tools

--- a/Singularity.def
+++ b/Singularity.def
@@ -5,6 +5,7 @@ From: ubuntu:20.04
 PERL5LIB=/bioinf-tools/vcftools-0.1.15/install/share/perl/5.30.0/:/bioinf-tools/cortex/scripts/analyse_variants/bioinf-perl/lib:/bioinf-tools/cortex/scripts/calling/:$PERL5LIB
 export PERL5LIB
 PATH=/bioinf-tools/:/bioinf-tools/cortex/bin/:/bioinf-tools/cortex/scripts/analyse_variants/seq-align/bin/:/bioinf-tools/vcftools-0.1.15/install/bin:/bioinf-tools/enaBrowserTools/python3:/clockwork/scripts/:$PATH
+NXF_VER=22.10.0
 
 %setup
     mkdir $SINGULARITY_ROOTFS/clockwork
@@ -15,6 +16,7 @@ PATH=/bioinf-tools/:/bioinf-tools/cortex/bin/:/bioinf-tools/cortex/scripts/analy
     export PATH=/bioinf-tools/:/bioinf-tools/cortex/bin/:/bioinf-tools/cortex/scripts/analyse_variants/seq-align/bin/:/bioinf-tools/vcftools-0.1.15/install/bin:/bioinf-tools/enaBrowserTools/python3:/clockwork/scripts/:$PATH
     export PERL5LIB=/bioinf-tools/vcftools-0.1.15/install/share/perl/5.30.0/:/bioinf-tools/cortex/scripts/analyse_variants/bioinf-perl/lib:/bioinf-tools/cortex/scripts/calling/:$PERL5LIB
     export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+    export NXF_VER=22.10.0
 
     #_________________ install dependencies __________________#
     /clockwork/scripts/install_dependencies.sh /bioinf-tools

--- a/multipass/README.md
+++ b/multipass/README.md
@@ -20,5 +20,5 @@ The VM has your host $HOME directory mounted as $HOME/Home in the VM.
 You can run the tests by navigating to the `python/` directory and running:
 
 ```
-python3 setup.py test
+NXF_VER=22.10.0 python3 setup.py test
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -40,7 +40,7 @@ dependencies in the Vagrant VM and in the Singularity container.
 
 Run the tests:
 
-    python3 setup.py test
+    NXF_VER=22.10.0 python3 setup.py test
 
 If the tests pass, install:
 


### PR DESCRIPTION
The nextflow scripts are all in DSL1. The build fails because latest nextflow (23.04.1.5866 at the time of writing) has dropped DSL1 support. This forces nextflow 22.10.0 when building/running tests.

Seeing as is trivial to choose a nextflow version at run time with `NXF_VER=22.10.0`, not going to update the clockwork nextflow scripts to DSL2.

Closes #109 